### PR TITLE
Revert "Bump idna from 2.10 to 3.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Flask-SocketIO==5.0.1
 gevent==21.1.2
 gevent-websocket==0.10.1
 greenlet==1.0.0
-idna==3.1
+idna==2.10
 iniconfig==1.1.1
 itsdangerous==1.1.0
 Jinja2==2.11.3


### PR DESCRIPTION
ERROR: Cannot install -r requirements.txt (line 36) and idna==3.1 because these package versions have conflicting dependencies.

The conflict is caused by:
The user requested idna==3.1
requests 2.25.1 depends on idna<3 and >=2.5